### PR TITLE
Extract configuration to external file

### DIFF
--- a/proxy/configuration/configure.php
+++ b/proxy/configuration/configure.php
@@ -1,13 +1,13 @@
 <?php
 
 use Tent\Configuration;
-use Tent\ProxyTarget;
+use Tent\Rule;
 use Tent\ProxyRequestHandler;
 use Tent\Server;
 use Tent\RequestMatcher;
 
-Configuration::addTarget(
-    new ProxyTarget(
+Configuration::addRule(
+    new Rule(
         new ProxyRequestHandler(new Server('http://frontend:8080')),
         [
             new RequestMatcher('GET', '/', 'exact'),

--- a/proxy/configuration/configure.php
+++ b/proxy/configuration/configure.php
@@ -1,0 +1,22 @@
+<?php
+
+use Tent\Configuration;
+use Tent\ProxyTarget;
+use Tent\ProxyRequestHandler;
+use Tent\Server;
+use Tent\RequestMatcher;
+
+Configuration::addTarget(
+    new ProxyTarget(
+        new ProxyRequestHandler(new Server('http://frontend:8080')),
+        [
+            new RequestMatcher('GET', '/', 'exact'),
+            new RequestMatcher('GET', '/assets/images/', 'begins_with'),
+            new RequestMatcher('GET', '/assets/js/', 'begins_with'),
+            new RequestMatcher('GET', '/assets/css/', 'begins_with'),
+            new RequestMatcher('GET', '/@vite/', 'begins_with'),
+            new RequestMatcher('GET', '/node_modules/', 'begins_with'),
+            new RequestMatcher('GET', '/@react-refresh', 'exact')
+        ]
+    )
+);

--- a/proxy/source/index.php
+++ b/proxy/source/index.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/lib/models/Response.php';
 require_once __DIR__ . '/lib/models/MissingResponse.php';
 require_once __DIR__ . '/lib/models/Request.php';
 require_once __DIR__ . '/lib/models/Server.php';
-require_once __DIR__ . '/lib/models/ProxyTarget.php';
+require_once __DIR__ . '/lib/models/Rule.php';
 require_once __DIR__ . '/lib/utils/CurlUtils.php';
 require_once __DIR__ . '/lib/http/HttpClientInterface.php';
 require_once __DIR__ . '/lib/http/CurlHttpClient.php';

--- a/proxy/source/index.php
+++ b/proxy/source/index.php
@@ -18,6 +18,11 @@ require_once __DIR__ . '/lib/models/RequestMatcher.php';
 require_once __DIR__ . '/lib/Configuration.php';
 require_once __DIR__ . '/lib/service/RequestProcessor.php';
 
+$configFile = __DIR__ . '/../configuration/configure.php';
+if (file_exists($configFile)) {
+    require_once $configFile;
+}
+
 function send_response($response)
 {
     http_response_code($response->httpCode);

--- a/proxy/source/index.php
+++ b/proxy/source/index.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/lib/handlers/RequestHandler.php';
 require_once __DIR__ . '/lib/handlers/ProxyRequestHandler.php';
 require_once __DIR__ . '/lib/handlers/MissingRequestHandler.php';
 require_once __DIR__ . '/lib/models/RequestMatcher.php';
+require_once __DIR__ . '/lib/Configuration.php';
 require_once __DIR__ . '/lib/service/RequestProcessor.php';
 
 function send_response($response)

--- a/proxy/source/lib/Configuration.php
+++ b/proxy/source/lib/Configuration.php
@@ -4,18 +4,18 @@ namespace Tent;
 
 class Configuration
 {
-    private static $targets = [];
+    private static $rules = [];
 
-    public static function addTarget($target)
+    public static function addRule($rule)
     {
-        self::$targets[] = $target;
+        self::$rules[] = $rule;
     }
 
-    public static function getTargets()
+    public static function getRules()
     {
         return array_merge(
-            self::$targets,
-            [new ProxyTarget(new MissingRequestHandler())]
+            self::$rules,
+            [new Rule(new MissingRequestHandler())]
         );
     }
 }

--- a/proxy/source/lib/Configuration.php
+++ b/proxy/source/lib/Configuration.php
@@ -13,7 +13,10 @@ class Configuration
 
     public static function getTargets()
     {
-        return self::$targets;
+        return array_merge(
+            self::$targets,
+            [new ProxyTarget(new MissingRequestHandler())]
+        );
     }
 }
 
@@ -31,5 +34,3 @@ Configuration::addTarget(
         ]
     )
 );
-
-Configuration::addTarget(new ProxyTarget(new MissingRequestHandler()));

--- a/proxy/source/lib/Configuration.php
+++ b/proxy/source/lib/Configuration.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tent;
+
+class Configuration
+{
+    public static function getTargets()
+    {
+        return [
+            new ProxyTarget(
+                new ProxyRequestHandler(new Server('http://frontend:8080')),
+                [
+                    new RequestMatcher('GET', '/', 'exact'),
+                    new RequestMatcher('GET', '/assets/images/', 'begins_with'),
+                    new RequestMatcher('GET', '/assets/js/', 'begins_with'),
+                    new RequestMatcher('GET', '/assets/css/', 'begins_with'),
+                    new RequestMatcher('GET', '/@vite/', 'begins_with'),
+                    new RequestMatcher('GET', '/node_modules/', 'begins_with'),
+                    new RequestMatcher('GET', '/@react-refresh', 'exact')
+                ]
+            ),
+            new ProxyTarget(new MissingRequestHandler())
+        ];
+    }
+}

--- a/proxy/source/lib/Configuration.php
+++ b/proxy/source/lib/Configuration.php
@@ -4,22 +4,32 @@ namespace Tent;
 
 class Configuration
 {
+    private static $targets = [];
+
+    public static function addTarget($target)
+    {
+        self::$targets[] = $target;
+    }
+
     public static function getTargets()
     {
-        return [
-            new ProxyTarget(
-                new ProxyRequestHandler(new Server('http://frontend:8080')),
-                [
-                    new RequestMatcher('GET', '/', 'exact'),
-                    new RequestMatcher('GET', '/assets/images/', 'begins_with'),
-                    new RequestMatcher('GET', '/assets/js/', 'begins_with'),
-                    new RequestMatcher('GET', '/assets/css/', 'begins_with'),
-                    new RequestMatcher('GET', '/@vite/', 'begins_with'),
-                    new RequestMatcher('GET', '/node_modules/', 'begins_with'),
-                    new RequestMatcher('GET', '/@react-refresh', 'exact')
-                ]
-            ),
-            new ProxyTarget(new MissingRequestHandler())
-        ];
+        return self::$targets;
     }
 }
+
+Configuration::addTarget(
+    new ProxyTarget(
+        new ProxyRequestHandler(new Server('http://frontend:8080')),
+        [
+            new RequestMatcher('GET', '/', 'exact'),
+            new RequestMatcher('GET', '/assets/images/', 'begins_with'),
+            new RequestMatcher('GET', '/assets/js/', 'begins_with'),
+            new RequestMatcher('GET', '/assets/css/', 'begins_with'),
+            new RequestMatcher('GET', '/@vite/', 'begins_with'),
+            new RequestMatcher('GET', '/node_modules/', 'begins_with'),
+            new RequestMatcher('GET', '/@react-refresh', 'exact')
+        ]
+    )
+);
+
+Configuration::addTarget(new ProxyTarget(new MissingRequestHandler()));

--- a/proxy/source/lib/Configuration.php
+++ b/proxy/source/lib/Configuration.php
@@ -19,18 +19,3 @@ class Configuration
         );
     }
 }
-
-Configuration::addTarget(
-    new ProxyTarget(
-        new ProxyRequestHandler(new Server('http://frontend:8080')),
-        [
-            new RequestMatcher('GET', '/', 'exact'),
-            new RequestMatcher('GET', '/assets/images/', 'begins_with'),
-            new RequestMatcher('GET', '/assets/js/', 'begins_with'),
-            new RequestMatcher('GET', '/assets/css/', 'begins_with'),
-            new RequestMatcher('GET', '/@vite/', 'begins_with'),
-            new RequestMatcher('GET', '/node_modules/', 'begins_with'),
-            new RequestMatcher('GET', '/@react-refresh', 'exact')
-        ]
-    )
-);

--- a/proxy/source/lib/models/Rule.php
+++ b/proxy/source/lib/models/Rule.php
@@ -2,7 +2,7 @@
 
 namespace Tent;
 
-class ProxyTarget
+class Rule
 {
     private $handler;
     private $matchers;

--- a/proxy/source/lib/service/RequestProcessor.php
+++ b/proxy/source/lib/service/RequestProcessor.php
@@ -25,31 +25,12 @@ class RequestProcessor
 
     private function getRequestHandler()
     {
-        $targets = $this->getTargets();
+        $targets = Configuration::getTargets();
 
         foreach ($targets as $target) {
             if ($target->match($this->request)) {
                 return $target->handler();
             }
         }
-    }
-
-    private function getTargets()
-    {
-        return [
-            new ProxyTarget(
-                new ProxyRequestHandler(new Server('http://frontend:8080')),
-                [
-                    new RequestMatcher('GET', '/', 'exact'),
-                    new RequestMatcher('GET', '/assets/images/', 'begins_with'),
-                    new RequestMatcher('GET', '/assets/js/', 'begins_with'),
-                    new RequestMatcher('GET', '/assets/css/', 'begins_with'),
-                    new RequestMatcher('GET', '/@vite/', 'begins_with'),
-                    new RequestMatcher('GET', '/node_modules/', 'begins_with'),
-                    new RequestMatcher('GET', '/@react-refresh', 'exact')
-                ]
-            ),
-            new ProxyTarget(new MissingRequestHandler())
-        ];
     }
 }

--- a/proxy/source/lib/service/RequestProcessor.php
+++ b/proxy/source/lib/service/RequestProcessor.php
@@ -25,11 +25,11 @@ class RequestProcessor
 
     private function getRequestHandler()
     {
-        $targets = Configuration::getTargets();
+        $rules = Configuration::getRules();
 
-        foreach ($targets as $target) {
-            if ($target->match($this->request)) {
-                return $target->handler();
+        foreach ($rules as $rule) {
+            if ($rule->match($this->request)) {
+                return $rule->handler();
             }
         }
     }

--- a/proxy/tests/unit/lib/models/RuleTest.php
+++ b/proxy/tests/unit/lib/models/RuleTest.php
@@ -3,16 +3,16 @@
 namespace Tent\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Tent\ProxyTarget;
+use Tent\Rule;
 use Tent\RequestMatcher;
 use Tent\Request;
 
-require_once __DIR__ . '/../../../../source/lib/models/ProxyTarget.php';
+require_once __DIR__ . '/../../../../source/lib/models/Rule.php';
 require_once __DIR__ . '/../../../../source/lib/models/RequestMatcher.php';
 require_once __DIR__ . '/../../../../source/lib/models/Request.php';
 require_once __DIR__ . '/../../../../source/lib/handlers/RequestHandler.php';
 
-class ProxyTargetTest extends TestCase
+class RuleTest extends TestCase
 {
     public function testMatchReturnsTrueWhenAMatcherMatches()
     {
@@ -25,9 +25,9 @@ class ProxyTargetTest extends TestCase
         $matcher1 = new RequestMatcher('POST', '/test', 'exact');
         $matcher2 = new RequestMatcher('GET', '/test', 'exact');
 
-        $target = new ProxyTarget($handler, [$matcher1, $matcher2]);
+        $rule = new Rule($handler, [$matcher1, $matcher2]);
 
-        $this->assertTrue($target->match($request));
+        $this->assertTrue($rule->match($request));
     }
 
     public function testMatchReturnsFalseWhenNoMatcherMatches()
@@ -41,9 +41,9 @@ class ProxyTargetTest extends TestCase
         $matcher1 = new RequestMatcher('POST', '/test', 'exact');
         $matcher2 = new RequestMatcher('PUT', '/test', 'exact');
 
-        $target = new ProxyTarget($handler, [$matcher1, $matcher2]);
+        $rule = new Rule($handler, [$matcher1, $matcher2]);
 
-        $this->assertFalse($target->match($request));
+        $this->assertFalse($rule->match($request));
     }
 
     public function testMatchReturnsFalseWhenNoMatchers()
@@ -51,9 +51,9 @@ class ProxyTargetTest extends TestCase
         $request = $this->createMock(Request::class);
         $handler = $this->createMock(\Tent\RequestHandler::class);
 
-        $target = new ProxyTarget($handler, []);
+        $rule = new Rule($handler, []);
 
-        $this->assertFalse($target->match($request));
+        $this->assertFalse($rule->match($request));
     }
 
     public function testMatchReturnsFalseWhenMatchersNotProvided()
@@ -61,9 +61,9 @@ class ProxyTargetTest extends TestCase
         $request = $this->createMock(Request::class);
         $handler = $this->createMock(\Tent\RequestHandler::class);
 
-        $target = new ProxyTarget($handler);
+        $rule = new Rule($handler);
 
-        $this->assertFalse($target->match($request));
+        $this->assertFalse($rule->match($request));
     }
 
     public function testMatchReturnsTrueOnFirstMatch()
@@ -77,17 +77,17 @@ class ProxyTargetTest extends TestCase
         $matcher1 = new RequestMatcher('GET', '/test', 'exact');
         $matcher2 = new RequestMatcher('GET', '/other', 'exact');
 
-        $target = new ProxyTarget($handler, [$matcher1, $matcher2]);
+        $rule = new Rule($handler, [$matcher1, $matcher2]);
 
-        $this->assertTrue($target->match($request));
+        $this->assertTrue($rule->match($request));
     }
 
     public function testHandlerReturnsTheHandler()
     {
         $handler = $this->createMock(\Tent\RequestHandler::class);
 
-        $target = new ProxyTarget($handler);
+        $rule = new Rule($handler);
 
-        $this->assertSame($handler, $target->handler());
+        $this->assertSame($handler, $rule->handler());
     }
 }


### PR DESCRIPTION
# Extract configuration to external file

Separate proxy routing configuration from code to enable different configurations per environment and facilitate code reuse in the Tent project.

## Changes

### New Class
- **Configuration**: Static class to manage routing rules
  - `addRule($rule)`: Register a routing rule
  - `getRules()`: Returns all registered rules + automatic MissingRequestHandler fallback

### Configuration File
- **configuration/configure.php**: External configuration file with routing rules
  - Loaded conditionally by index.php (only if exists)
  - Uses `Configuration::addRule()` to register routes
  - Can be customized per environment without changing proxy code

### Refactoring
- Renamed `ProxyTarget` → `Rule` (better reflects conditional routing concept)
- Renamed `ProxyTargetTest` → `RuleTest`
- Updated all methods: `addTarget()` → `addRule()`, `getTargets()` → `getRules()`

### Tests
- All 59 tests passing with 84 assertions
- RuleTest covers rule matching and handler retrieval

## Motivation

Enable different routing configurations for development vs production environments and prepare codebase for extraction to the [Tent project](https://github.com/darthjee/tent), where proxy logic can be reused with custom configurations.

---
See issue for details: https://github.com/darthjee/weave/issues/72