### PR TITLE
Handle 404 on Proxy RequestHandler

### DIFF
--- a/proxy/source/lib/Configuration.php
+++ b/proxy/source/lib/Configuration.php
@@ -18,4 +18,9 @@ class Configuration
             [new Rule(new MissingRequestHandler())]
         );
     }
+
+    public static function reset()
+    {
+        self::$rules = [];
+    }
 }

--- a/proxy/source/lib/models/Request.php
+++ b/proxy/source/lib/models/Request.php
@@ -4,23 +4,42 @@ namespace Tent;
 
 class Request
 {
+    private $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
     public function requestMethod()
     {
+        if (isset($this->options['requestMethod'])) {
+            return $this->options['requestMethod'];
+        }
         return $_SERVER['REQUEST_METHOD'];
     }
 
     public function body()
     {
+        if (isset($this->options['body'])) {
+            return $this->options['body'];
+        }
         return file_get_contents('php://input');
     }
 
     public function headers()
     {
+        if (isset($this->options['headers'])) {
+            return $this->options['headers'];
+        }
         return getallheaders();
     }
 
     public function requestUrl()
     {
+        if (isset($this->options['requestUrl'])) {
+            return $this->options['requestUrl'];
+        }
         $uri = $_SERVER['REQUEST_URI'];
         $parts = parse_url($uri);
         return $parts['path'] ?? '/';
@@ -28,6 +47,9 @@ class Request
 
     public function query()
     {
+        if (isset($this->options['query'])) {
+            return $this->options['query'];
+        }
         $uri = $_SERVER['REQUEST_URI'];
         $parts = parse_url($uri);
         return $parts['query'] ?? '';

--- a/proxy/source/lib/service/RequestProcessor.php
+++ b/proxy/source/lib/service/RequestProcessor.php
@@ -32,5 +32,7 @@ class RequestProcessor
                 return $rule->handler();
             }
         }
+
+        return new MissingRequestHandler();
     }
 }

--- a/proxy/tests/fixtures/static/index.html
+++ b/proxy/tests/fixtures/static/index.html
@@ -1,0 +1,1 @@
+<html><body>Hello from static index!</body></html>

--- a/proxy/tests/support/tests_loader.php
+++ b/proxy/tests/support/tests_loader.php
@@ -1,0 +1,7 @@
+<?php
+
+// tests_loader.php
+
+require_once __DIR__ . '/../../source/lib/Configuration.php';
+require_once __DIR__ . '/../../source/lib/service/RequestProcessor.php';
+require_once __DIR__ . '/../../source/lib/handlers/MissingRequestHandler.php';

--- a/proxy/tests/unit/lib/service/RequestProcessorTest.php
+++ b/proxy/tests/unit/lib/service/RequestProcessorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tent\Tests;
+
+require_once __DIR__ . '/../../../support/tests_loader.php';
+
+use PHPUnit\Framework\TestCase;
+use Tent\RequestProcessor;
+use Tent\Configuration;
+use Tent\Rule;
+use Tent\ProxyRequestHandler;
+use Tent\StaticFileHandler;
+use Tent\FolderLocation;
+use Tent\Request;
+use Tent\Response;
+use Tent\RequestMatcher;
+use Tent\Server;
+
+class RequestProcessorTest extends TestCase
+{
+    private $staticPath;
+
+    protected function setupStatic()
+    {
+        $this->staticPath = __DIR__ . '/../../../fixtures/static';
+        $staticLocation = new FolderLocation($this->staticPath);
+
+        Configuration::addRule(
+            new Rule(new StaticFileHandler($staticLocation), [
+                new RequestMatcher('GET', '/index.html', 'exact')
+            ])
+        );
+    }
+
+    protected function setupProxy()
+    {
+        $server = new Server('http://httpbin');
+
+        Configuration::addRule(
+            new Rule(new ProxyRequestHandler($server), [
+                new RequestMatcher('GET', '/get', 'exact')
+            ])
+        );
+    }
+
+    protected function setUp(): void
+    {
+        // Reset rules before each test
+        Configuration::reset();
+        $this->setupStatic();
+        $this->setupProxy();
+    }
+
+    public function testStaticFileHandlerReturnsIndexHtml()
+    {
+
+        // Create a request to /index.html using named parameters
+        $request = new Request([
+            'requestUrl' => '/index.html',
+            'requestMethod' => 'GET'
+        ]);
+        $response = RequestProcessor::handleRequest($request);
+
+        $expectedContent = file_get_contents($this->staticPath . '/index.html');
+        $this->assertInstanceOf(\Tent\Response::class, $response);
+        $this->assertEquals(200, $response->httpCode);
+        $this->assertEquals($expectedContent, $response->body);
+        $this->assertStringContainsString('Content-Type: text/html', implode("\n", $response->headerLines));
+    }
+
+    public function testProxyRequestHandlerForwardsToHttpbin()
+    {
+        // Setup ProxyRequestHandler to httpbin
+        $server = new Server('http://httpbin');
+        $request = new Request([
+            'requestUrl' => '/get',
+            'requestMethod' => 'GET',
+            'query' => '',
+            'headers' => []
+        ]);
+        $response = RequestProcessor::handleRequest($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->httpCode);
+        $this->assertNotEmpty($response->body);
+        // httpbin returns JSON for /anything and /get endpoints, so we check for JSON
+        $json = json_decode($response->body, true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('url', $json);
+        $this->assertStringContainsString('/get', $json['url']);
+    }
+
+    public function testReturnsMissingResponseForUnmatchedRoute()
+    {
+        // No rules added, so fallback handler should be used
+        $request = new \Tent\Request([
+            'requestUrl' => '/other',
+            'requestMethod' => 'GET'
+        ]);
+        $response = \Tent\RequestProcessor::handleRequest($request);
+
+        $this->assertInstanceOf(\Tent\Response::class, $response);
+        $this->assertEquals(404, $response->httpCode);
+        $this->assertStringContainsString('Not Found', $response->body);
+    }
+}


### PR DESCRIPTION
# PR #76: Handle 404 on Proxy RequestHandler

## Summary

This PR improves the proxy by ensuring that unknown or unmatched routes return a proper 404 response, instead of failing silently or returning unexpected results. This brings the proxy in line with standard web server behavior and improves reliability for frontend and API consumers.

## Changes

- Added fallback to `MissingRequestHandler` for unmatched routes in `RequestProcessor`
- Extended `Request` model to allow testable, injectable request parameters (method, url, headers, body, query)
- Added `Configuration::reset()` for easier test isolation
- Added and improved unit tests for:
  - Static file handler (serving known files)
  - Proxy handler (forwarding to backend)
  - 404 handler (unmatched routes)
- Added test fixture for static index.html
- Added test loader for easier test setup

## Benefits
- Proxy now returns a 404 Not Found for unknown routes
- More robust and predictable routing behavior
- Improved test coverage and isolation for request handling
- Better developer experience for debugging and extending proxy rules
