### PR TITLE
Reorganize proxy file loading

### DIFF
--- a/proxy/source/index.php
+++ b/proxy/source/index.php
@@ -3,22 +3,23 @@
 use Tent\Request;
 use Tent\RequestProcessor;
 
-require_once __DIR__ . '/lib/models/Response.php';
-require_once __DIR__ . '/lib/models/MissingResponse.php';
-require_once __DIR__ . '/lib/models/Request.php';
-require_once __DIR__ . '/lib/models/Server.php';
-require_once __DIR__ . '/lib/models/FolderLocation.php';
-require_once __DIR__ . '/lib/models/Rule.php';
-require_once __DIR__ . '/lib/utils/CurlUtils.php';
-require_once __DIR__ . '/lib/http/HttpClientInterface.php';
-require_once __DIR__ . '/lib/http/CurlHttpClient.php';
 require_once __DIR__ . '/lib/handlers/RequestHandler.php';
+require_once __DIR__ . '/lib/http/HttpClientInterface.php';
+require_once __DIR__ . '/lib/models/Response.php';
+
+require_once __DIR__ . '/lib/Configuration.php';
+require_once __DIR__ . '/lib/handlers/MissingRequestHandler.php';
 require_once __DIR__ . '/lib/handlers/ProxyRequestHandler.php';
 require_once __DIR__ . '/lib/handlers/StaticFileHandler.php';
-require_once __DIR__ . '/lib/handlers/MissingRequestHandler.php';
+require_once __DIR__ . '/lib/http/CurlHttpClient.php';
+require_once __DIR__ . '/lib/models/FolderLocation.php';
+require_once __DIR__ . '/lib/models/MissingResponse.php';
+require_once __DIR__ . '/lib/models/Request.php';
 require_once __DIR__ . '/lib/models/RequestMatcher.php';
-require_once __DIR__ . '/lib/Configuration.php';
+require_once __DIR__ . '/lib/models/Rule.php';
+require_once __DIR__ . '/lib/models/Server.php';
 require_once __DIR__ . '/lib/service/RequestProcessor.php';
+require_once __DIR__ . '/lib/utils/CurlUtils.php';
 
 $configFile = __DIR__ . '/configuration/configure.php';
 if (file_exists($configFile)) {

--- a/proxy/source/lib/handlers/MissingRequestHandler.php
+++ b/proxy/source/lib/handlers/MissingRequestHandler.php
@@ -2,6 +2,8 @@
 
 namespace Tent;
 
+use Tent\RequestHandler;
+
 class MissingRequestHandler implements RequestHandler
 {
     public function handleRequest($request)

--- a/proxy/source/lib/http/CurlHttpClient.php
+++ b/proxy/source/lib/http/CurlHttpClient.php
@@ -2,6 +2,8 @@
 
 namespace Tent;
 
+use Tent\HttpClientInterface;
+
 class CurlHttpClient implements HttpClientInterface
 {
     public function request($url, $headers)

--- a/proxy/source/lib/models/MissingResponse.php
+++ b/proxy/source/lib/models/MissingResponse.php
@@ -2,6 +2,8 @@
 
 namespace Tent;
 
+use Tent\Response;
+
 class MissingResponse extends Response
 {
     public function __construct()

--- a/proxy/tests/support/tests_loader.php
+++ b/proxy/tests/support/tests_loader.php
@@ -2,6 +2,20 @@
 
 // tests_loader.php
 
+require_once __DIR__ . '/../../source/lib/handlers/RequestHandler.php';
+require_once __DIR__ . '/../../source/lib/http/HttpClientInterface.php';
+require_once __DIR__ . '/../../source/lib/models/Response.php';
+
 require_once __DIR__ . '/../../source/lib/Configuration.php';
-require_once __DIR__ . '/../../source/lib/service/RequestProcessor.php';
 require_once __DIR__ . '/../../source/lib/handlers/MissingRequestHandler.php';
+require_once __DIR__ . '/../../source/lib/handlers/ProxyRequestHandler.php';
+require_once __DIR__ . '/../../source/lib/handlers/StaticFileHandler.php';
+require_once __DIR__ . '/../../source/lib/http/CurlHttpClient.php';
+require_once __DIR__ . '/../../source/lib/models/FolderLocation.php';
+require_once __DIR__ . '/../../source/lib/models/MissingResponse.php';
+require_once __DIR__ . '/../../source/lib/models/Request.php';
+require_once __DIR__ . '/../../source/lib/models/RequestMatcher.php';
+require_once __DIR__ . '/../../source/lib/models/Rule.php';
+require_once __DIR__ . '/../../source/lib/models/Server.php';
+require_once __DIR__ . '/../../source/lib/service/RequestProcessor.php';
+require_once __DIR__ . '/../../source/lib/utils/CurlUtils.php';

--- a/proxy/tests/unit/lib/handlers/ProxyRequestHandlerTest.php
+++ b/proxy/tests/unit/lib/handlers/ProxyRequestHandlerTest.php
@@ -8,12 +8,7 @@ use Tent\Request;
 use Tent\Response;
 use Tent\Server;
 
-require_once __DIR__ . '/../../../../source/lib/handlers/RequestHandler.php';
-require_once __DIR__ . '/../../../../source/lib/handlers/ProxyRequestHandler.php';
-require_once __DIR__ . '/../../../../source/lib/models/Request.php';
-require_once __DIR__ . '/../../../../source/lib/models/Response.php';
-require_once __DIR__ . '/../../../../source/lib/models/Server.php';
-require_once __DIR__ . '/../../../../source/lib/http/HttpClientInterface.php';
+require_once __DIR__ . '/../../../support/tests_loader.php';
 
 class ProxyRequestHandlerTest extends TestCase
 {

--- a/proxy/tests/unit/lib/handlers/StaticFileHandlerTest.php
+++ b/proxy/tests/unit/lib/handlers/StaticFileHandlerTest.php
@@ -8,12 +8,7 @@ use Tent\FolderLocation;
 use Tent\Request;
 use Tent\MissingResponse;
 
-require_once __DIR__ . '/../../../../source/lib/handlers/RequestHandler.php';
-require_once __DIR__ . '/../../../../source/lib/handlers/StaticFileHandler.php';
-require_once __DIR__ . '/../../../../source/lib/models/FolderLocation.php';
-require_once __DIR__ . '/../../../../source/lib/models/Request.php';
-require_once __DIR__ . '/../../../../source/lib/models/Response.php';
-require_once __DIR__ . '/../../../../source/lib/models/MissingResponse.php';
+require_once __DIR__ . '/../../../support/tests_loader.php';
 
 class StaticFileHandlerTest extends TestCase
 {

--- a/proxy/tests/unit/lib/http/CurlHttpClientTest.php
+++ b/proxy/tests/unit/lib/http/CurlHttpClientTest.php
@@ -5,9 +5,7 @@ namespace Tent\Tests;
 use PHPUnit\Framework\TestCase;
 use Tent\CurlHttpClient;
 
-require_once __DIR__ . '/../../../../source/lib/http/HttpClientInterface.php';
-require_once __DIR__ . '/../../../../source/lib/http/CurlHttpClient.php';
-require_once __DIR__ . '/../../../../source/lib/utils/CurlUtils.php';
+require_once __DIR__ . '/../../../support/tests_loader.php';
 
 class CurlHttpClientTest extends TestCase
 {

--- a/proxy/tests/unit/lib/models/FolderLocationTest.php
+++ b/proxy/tests/unit/lib/models/FolderLocationTest.php
@@ -5,7 +5,7 @@ namespace Tent\Tests;
 use PHPUnit\Framework\TestCase;
 use Tent\FolderLocation;
 
-require_once __DIR__ . '/../../../../source/lib/models/FolderLocation.php';
+require_once __DIR__ . '/../../../support/tests_loader.php';
 
 class FolderLocationTest extends TestCase
 {

--- a/proxy/tests/unit/lib/models/MissingResponseTest.php
+++ b/proxy/tests/unit/lib/models/MissingResponseTest.php
@@ -5,9 +5,6 @@ namespace Tent\Tests;
 use PHPUnit\Framework\TestCase;
 use Tent\MissingResponse;
 
-require_once __DIR__ . '/../../../../source/lib/models/Response.php';
-require_once __DIR__ . '/../../../../source/lib/models/MissingResponse.php';
-
 class MissingResponseTest extends TestCase
 {
     public function testCreatesResponseWith404StatusCode()

--- a/proxy/tests/unit/lib/models/RequestMatcherTest.php
+++ b/proxy/tests/unit/lib/models/RequestMatcherTest.php
@@ -6,9 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Tent\RequestMatcher;
 use Tent\Request;
 
-require_once __DIR__ . '/../../../../source/lib/models/RequestMatcher.php';
-require_once __DIR__ . '/../../../../source/lib/models/Request.php';
-
 class RequestMatcherTest extends TestCase
 {
     public function testMatchesWithExactMatch()

--- a/proxy/tests/unit/lib/models/RequestTest.php
+++ b/proxy/tests/unit/lib/models/RequestTest.php
@@ -5,8 +5,6 @@ namespace Tent\Tests;
 use PHPUnit\Framework\TestCase;
 use Tent\Request;
 
-require_once __DIR__ . '/../../../../source/lib/models/Request.php';
-
 class RequestTest extends TestCase
 {
     private $originalServer;

--- a/proxy/tests/unit/lib/models/RuleTest.php
+++ b/proxy/tests/unit/lib/models/RuleTest.php
@@ -7,11 +7,6 @@ use Tent\Rule;
 use Tent\RequestMatcher;
 use Tent\Request;
 
-require_once __DIR__ . '/../../../../source/lib/models/Rule.php';
-require_once __DIR__ . '/../../../../source/lib/models/RequestMatcher.php';
-require_once __DIR__ . '/../../../../source/lib/models/Request.php';
-require_once __DIR__ . '/../../../../source/lib/handlers/RequestHandler.php';
-
 class RuleTest extends TestCase
 {
     public function testMatchReturnsTrueWhenAMatcherMatches()

--- a/proxy/tests/unit/lib/service/RequestProcessorTest.php
+++ b/proxy/tests/unit/lib/service/RequestProcessorTest.php
@@ -2,8 +2,6 @@
 
 namespace Tent\Tests;
 
-require_once __DIR__ . '/../../../support/tests_loader.php';
-
 use PHPUnit\Framework\TestCase;
 use Tent\RequestProcessor;
 use Tent\Configuration;

--- a/proxy/tests/unit/lib/utils/CurlUtilsTest.php
+++ b/proxy/tests/unit/lib/utils/CurlUtilsTest.php
@@ -5,8 +5,6 @@ namespace Tent\Tests;
 use PHPUnit\Framework\TestCase;
 use Tent\CurlUtils;
 
-require_once __DIR__ . '/../../../../source/lib/utils/CurlUtils.php';
-
 class CurlUtilsTest extends TestCase
 {
     public function testBuildHeaderLinesWithSingleHeader()


### PR DESCRIPTION
## PR Description

This pull request reorganizes and alphabetizes require_once statements across several files to improve code clarity and maintainability. Duplicate and unnecessary require_once calls were removed, reducing repetition and making dependencies easier to manage. No functional changes were made.
