### PR TITLE
Add Proxy Middleware

### DIFF
--- a/proxy/source/index.php
+++ b/proxy/source/index.php
@@ -19,11 +19,11 @@ if (file_exists($configFile)) {
  */
 function send_response(Response $response)
 {
-    http_response_code($response->httpCode);
-    foreach ($response->headerLines as $header) {
+    http_response_code($response->httpCode());
+    foreach ($response->headerLines() as $header) {
         header($header);
     }
-    echo $response->body;
+    echo $response->body();
 }
 
 $request = new Request();

--- a/proxy/source/lib/handlers/FileHandler.php
+++ b/proxy/source/lib/handlers/FileHandler.php
@@ -46,7 +46,7 @@ abstract class FileHandler extends RequestHandler
      * @return Response The HTTP response containing the file contents, or MissingResponse if not found.
      * @see ContentType::getContentType()
      */
-    public function handleRequest(RequestInterface $request)
+    protected function processsRequest(RequestInterface $request)
     {
         try {
             $this->validateFilePath($request->requestUrl());

--- a/proxy/source/lib/handlers/MissingRequestHandler.php
+++ b/proxy/source/lib/handlers/MissingRequestHandler.php
@@ -20,7 +20,7 @@ class MissingRequestHandler extends RequestHandler
      * @param RequestInterface $request The incoming HTTP request.
      * @return MissingResponse The 404 response.
      */
-    public function handleRequest(RequestInterface $request)
+    protected function processsRequest(RequestInterface $request)
     {
         return new MissingResponse();
     }

--- a/proxy/source/lib/handlers/ProxyRequestHandler.php
+++ b/proxy/source/lib/handlers/ProxyRequestHandler.php
@@ -61,7 +61,7 @@ class ProxyRequestHandler extends RequestHandler
      * @param RequestInterface $request The incoming HTTP request to be proxied.
      * @return Response The response from the target server.
      */
-    public function handleRequest(RequestInterface $request)
+    protected function processsRequest(RequestInterface $request)
     {
         // Build full URL from target host and request path
         $url = $this->server->targetHost() . $request->requestUrl();

--- a/proxy/source/lib/middlewares/RequestMiddleware.php
+++ b/proxy/source/lib/middlewares/RequestMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tent\Middlewares;
+
+use Tent\Models\ProcessingRequest;
+
+/**
+ * Interface for request middlewares that can process or modify a ProcessingRequest.
+ */
+interface RequestMiddleware
+{
+    /**
+     * Processes or modifies the given ProcessingRequest.
+     *
+     * @param ProcessingRequest $request The request to process.
+     * @return ProcessingRequest The (possibly modified) request.
+     */
+    public function process(ProcessingRequest $request): ProcessingRequest;
+}

--- a/proxy/source/lib/middlewares/SetHeadersMiddleware.php
+++ b/proxy/source/lib/middlewares/SetHeadersMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tent\Middlewares;
+
+use Tent\Models\ProcessingRequest;
+
+/**
+ * Middleware to set or override headers in a ProcessingRequest.
+ */
+class SetHeadersMiddleware implements RequestMiddleware
+{
+    /**
+     * @var array<string, string> Headers to set
+     */
+    private $headers;
+
+    /**
+     * @param array<string, string> $headers Associative array of headers
+     *   to set (e.g., ['Host' => 'some_host']).
+     */
+    public function __construct(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * Sets or overrides headers in the ProcessingRequest.
+     *
+     * @param ProcessingRequest $request The request to process.
+     * @return ProcessingRequest The modified request
+     */
+    public function process(ProcessingRequest $request): ProcessingRequest
+    {
+        foreach ($this->headers as $name => $value) {
+            $request->setHeader($name, $value);
+        }
+        return $request;
+    }
+}

--- a/proxy/source/lib/models/Response.php
+++ b/proxy/source/lib/models/Response.php
@@ -12,17 +12,17 @@ class Response
     /**
      * @var string Response body content
      */
-    public $body;
+    private string $body;
 
     /**
      * @var int HTTP status code (e.g., 200, 404)
      */
-    public $httpCode;
+    private int $httpCode;
 
     /**
      * @var array List of HTTP header lines (e.g., ['Content-Type: text/html'])
      */
-    public $headerLines;
+    private array $headerLines;
 
     /**
      * Constructs a Response object.
@@ -36,5 +36,35 @@ class Response
         $this->body = $body;
         $this->httpCode = $httpCode;
         $this->headerLines = $headerLines;
+    }
+
+    /**
+     * Returns the response body content.
+     *
+     * @return string
+     */
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * Returns the HTTP status code.
+     *
+     * @return integer
+     */
+    public function httpCode(): int
+    {
+        return $this->httpCode;
+    }
+
+    /**
+     * Returns the list of HTTP header lines.
+     *
+     * @return array
+     */
+    public function headerLines(): array
+    {
+        return $this->headerLines;
     }
 }

--- a/proxy/source/lib/service/RequestProcessor.php
+++ b/proxy/source/lib/service/RequestProcessor.php
@@ -20,7 +20,7 @@ class RequestProcessor
     /**
      * @var ProcessingRequest The incoming HTTP request to be processed.
      */
-    private $request;
+    private ProcessingRequest $request;
 
     /**
      * Constructs a RequestProcessor.

--- a/proxy/source/loader.php
+++ b/proxy/source/loader.php
@@ -16,6 +16,8 @@ require_once __DIR__ . '/lib/handlers/MissingRequestHandler.php';
 require_once __DIR__ . '/lib/handlers/ProxyRequestHandler.php';
 require_once __DIR__ . '/lib/handlers/StaticFileHandler.php';
 require_once __DIR__ . '/lib/http/CurlHttpClient.php';
+require_once __DIR__ . '/lib/middlewares/RequestMiddleware.php';
+require_once __DIR__ . '/lib/middlewares/SetHeadersMiddleware.php';
 require_once __DIR__ . '/lib/models/FolderLocation.php';
 require_once __DIR__ . '/lib/models/ForbiddenResponse.php';
 require_once __DIR__ . '/lib/models/MissingResponse.php';

--- a/proxy/tests/support/handlers/RequestToBodyHandler.php
+++ b/proxy/tests/support/handlers/RequestToBodyHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tent\Tests\Support\Handlers;
+
+use Tent\Handlers\RequestHandler;
+use Tent\Models\RequestInterface;
+use Tent\Models\Response;
+
+/**
+ * Test handler that will be used only for testing purposes.
+ * The processRequest method should be implemented as needed in tests.
+ */
+class RequestToBodyHandler extends RequestHandler
+{
+    /**
+     * Implement this method in your test to define the handler's behavior.
+     *
+     * @param RequestInterface $request
+     * @return Response
+     */
+    protected function processsRequest(RequestInterface $request)
+    {
+        $body = json_encode([
+            'uri' => $request->requestUrl(),
+            'query' => $request->query(),
+            'method' => $request->requestMethod(),
+            'headers' => $request->headers(),
+            'body' => $request->body(),
+        ]);
+        return new Response(
+            $body,
+            200,
+            ['Content-Type: application/json']
+        );
+    }
+}

--- a/proxy/tests/support/middlewares/DummyMiddleware.php
+++ b/proxy/tests/support/middlewares/DummyMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tent\Tests\Support\Middlewares;
+
+use Tent\Middlewares\RequestMiddleware;
+use Tent\Models\ProcessingRequest;
+
+class DummyMiddleware implements RequestMiddleware
+{
+    public function process(ProcessingRequest $request): ProcessingRequest
+    {
+        $request->setHeader('X-Test', 'middleware');
+        return $request;
+    }
+}

--- a/proxy/tests/unit/lib/handlers/FixedFileHandler/FixedFileHandlerGeneralTest.php
+++ b/proxy/tests/unit/lib/handlers/FixedFileHandler/FixedFileHandlerGeneralTest.php
@@ -3,6 +3,7 @@
 namespace Tent\Tests;
 
 use Tent\Handlers\FixedFileHandler;
+use Tent\Models\ProcessingRequest;
 use Tent\Models\Request;
 use Tent\Models\Response;
 use Tent\Models\MissingResponse;
@@ -16,46 +17,46 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/content.html');
 
-        $request = new Request(['requestUrl' => '/some-url']);
+        $request = new ProcessingRequest(['requestUrl' => '/some-url']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertStringContainsString('Hello, FixedFileHandler!', $response->body);
-        $this->assertContains('Content-Type: text/html', $response->headerLines);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertStringContainsString('Hello, FixedFileHandler!', $response->body());
+        $this->assertContains('Content-Type: text/html', $response->headerLines());
     }
 
     public function testReturnsJsonFileContent()
     {
         $handler = new FixedFileHandler('./tests/fixtures/data.json');
 
-        $request = new Request(['requestUrl' => '/some-url.json']);
+        $request = new ProcessingRequest(['requestUrl' => '/some-url.json']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertStringContainsString('Hello, JSON!', $response->body);
-        $this->assertContains('Content-Type: application/json', $response->headerLines);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertStringContainsString('Hello, JSON!', $response->body());
+        $this->assertContains('Content-Type: application/json', $response->headerLines());
     }
 
     public function testReturnsImageFileContent()
     {
         $handler = new FixedFileHandler('./tests/fixtures/image.gif');
 
-        $request = new Request(['requestUrl' => '/some-url.gif']);
+        $request = new ProcessingRequest(['requestUrl' => '/some-url.gif']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertNotEmpty($response->body);
-        $this->assertContains('Content-Type: image/gif', $response->headerLines);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertNotEmpty($response->body());
+        $this->assertContains('Content-Type: image/gif', $response->headerLines());
     }
 
     public function testReturnsMissingResponseWhenFileNotFound()
     {
         $handler = new FixedFileHandler('./tests/fixtures/nonexistent.txt');
 
-        $request = new Request(['requestUrl' => '/some-url.txt']);
+        $request = new ProcessingRequest(['requestUrl' => '/some-url.txt']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(MissingResponse::class, $response);
@@ -65,24 +66,24 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/style.css');
 
-        $request = new Request(['requestUrl' => '/some-url.css']);
+        $request = new ProcessingRequest(['requestUrl' => '/some-url.css']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertStringContainsString('background: #fff', $response->body);
-        $this->assertContains('Content-Type: text/css', $response->headerLines);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertStringContainsString('background: #fff', $response->body());
+        $this->assertContains('Content-Type: text/css', $response->headerLines());
     }
 
     public function testReturnsForbiddenResponseForPathTraversal()
     {
         $handler = new FixedFileHandler('./tests/fixtures/content.html');
 
-        $request = new Request(['requestUrl' => '/some-url.html']);
-        $request = new Request(['requestUrl' => '../etc/passwd']);
+        $request = new ProcessingRequest(['requestUrl' => '/some-url.html']);
+        $request = new ProcessingRequest(['requestUrl' => '../etc/passwd']);
 
         $response = $handler->handleRequest($request);
         $this->assertInstanceOf(ForbiddenResponse::class, $response);
-        $this->assertEquals(403, $response->httpCode);
+        $this->assertEquals(403, $response->httpCode());
     }
 }

--- a/proxy/tests/unit/lib/handlers/RequestHandler/RequestHandlerMiddlewareTest.php
+++ b/proxy/tests/unit/lib/handlers/RequestHandler/RequestHandlerMiddlewareTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tent\Tests\Handlers\RequestHandler;
+
+require_once __DIR__ . '/../../../../support/handlers/RequestToBodyHandler.php';
+require_once __DIR__ . '/../../../../support/middlewares/DummyMiddleware.php';
+
+use PHPUnit\Framework\TestCase;
+use Tent\Handlers\RequestHandler;
+use Tent\Models\ProcessingRequest;
+use Tent\Middlewares\RequestMiddleware;
+use Tent\Tests\Support\Handlers\RequestToBodyHandler;
+use Tent\Tests\Support\Middlewares\DummyMiddleware;
+
+class RequestHandlerMiddlewareTest extends TestCase
+{
+    public function testAddMiddlewareAndApplyMiddlewares()
+    {
+        $handler = new RequestToBodyHandler();
+        $middleware = new DummyMiddleware();
+        $handler->addRequestMiddleware($middleware);
+
+        $request = new ProcessingRequest([
+            'requestMethod' => 'GET',
+            'requestUrl' => '/test',
+            'headers' => [
+                'Accept' => 'application/json',
+            ]
+        ]);
+
+        $response = $handler->handleRequest($request);
+        $expected = [
+            'uri' => '/test',
+            'query' => null,
+            'method' => 'GET',
+            'body' => null,
+            'headers' => [
+                'X-Test' => 'middleware',
+                'Accept' => 'application/json',
+            ],
+        ];
+        $actual = json_decode($response->body(), true);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/proxy/tests/unit/lib/handlers/StaticFileHandler/StaticFileHandlerGeneralTest.php
+++ b/proxy/tests/unit/lib/handlers/StaticFileHandler/StaticFileHandlerGeneralTest.php
@@ -8,6 +8,7 @@ use Tent\Models\FolderLocation;
 use Tent\Models\Request;
 use Tent\Models\MissingResponse;
 use Tent\Models\ForbiddenResponse;
+use Tent\Models\ProcessingRequest;
 
 class StaticFileHandlerGeneralTest extends TestCase
 {
@@ -47,12 +48,13 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/test.txt');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertEquals('Hello World', $response->body);
-        $this->assertContains('Content-Type: text/plain', $response->headerLines);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertEquals('Hello World', $response->body());
+        $this->assertContains('Content-Type: text/plain', $response->headerLines());
     }
 
     public function testHandleRequestReturnsMissingResponseWhenFileDoesNotExist()
@@ -62,11 +64,12 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/nonexistent.txt');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
         $this->assertInstanceOf(MissingResponse::class, $response);
-        $this->assertEquals(404, $response->httpCode);
+        $this->assertEquals(404, $response->httpCode());
     }
 
     public function testHandleRequestReturnsCorrectContentTypeForHtml()
@@ -78,12 +81,13 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/index.html');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertCount(2, $response->headerLines);
-        $this->assertMatchesRegularExpression('/Content-Type: text\/html/', $response->headerLines[0]);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertCount(2, $response->headerLines());
+        $this->assertMatchesRegularExpression('/Content-Type: text\/html/', $response->headerLines()[0]);
     }
 
     public function testHandleRequestReturnsCorrectContentTypeForCss()
@@ -95,12 +99,13 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/style.css');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertCount(2, $response->headerLines);
-        $this->assertMatchesRegularExpression('/Content-Type: text\/css/', $response->headerLines[0]);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertCount(2, $response->headerLines());
+        $this->assertMatchesRegularExpression('/Content-Type: text\/css/', $response->headerLines()[0]);
     }
 
     public function testHandleRequestReturnsCorrectContentTypeForJs()
@@ -112,12 +117,13 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/script.js');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertCount(2, $response->headerLines);
-        $this->assertMatchesRegularExpression('/Content-Type: application\/javascript/', $response->headerLines[0]);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertCount(2, $response->headerLines());
+        $this->assertMatchesRegularExpression('/Content-Type: application\/javascript/', $response->headerLines()[0]);
     }
 
     public function testHandleRequestReturnsCorrectContentTypeForJson()
@@ -129,12 +135,13 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/data.json');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertCount(2, $response->headerLines);
-        $this->assertMatchesRegularExpression('/Content-Type: application\/json/', $response->headerLines[0]);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertCount(2, $response->headerLines());
+        $this->assertMatchesRegularExpression('/Content-Type: application\/json/', $response->headerLines()[0]);
     }
 
     public function testHandleRequestReturnsCorrectContentTypeForPng()
@@ -146,12 +153,13 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/image.png');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertCount(2, $response->headerLines);
-        $this->assertMatchesRegularExpression('/Content-Type: image\/png/', $response->headerLines[0]);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertCount(2, $response->headerLines());
+        $this->assertMatchesRegularExpression('/Content-Type: image\/png/', $response->headerLines()[0]);
     }
 
     public function testHandleRequestReturnsCorrectContentTypeForJpg()
@@ -163,12 +171,13 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/image.jpg');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertCount(2, $response->headerLines);
-        $this->assertMatchesRegularExpression('/Content-Type: image\/jpeg/', $response->headerLines[0]);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertCount(2, $response->headerLines());
+        $this->assertMatchesRegularExpression('/Content-Type: image\/jpeg/', $response->headerLines()[0]);
     }
 
     public function testHandleRequestReturnsMissingResponseForDirectory()
@@ -180,11 +189,12 @@ class StaticFileHandlerGeneralTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestUrl')->willReturn('/subdir');
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
 
         $this->assertInstanceOf(MissingResponse::class, $response);
-        $this->assertEquals(404, $response->httpCode);
+        $this->assertEquals(404, $response->httpCode());
     }
 
     public function testHandleRequestReturnsForbiddenResponseForPathTraversal()
@@ -192,9 +202,10 @@ class StaticFileHandlerGeneralTest extends TestCase
         $location = new FolderLocation($this->testDir);
         $handler = new StaticFileHandler($location);
         $request = new Request(['requestUrl' => '../etc/passwd']);
+        $processingRequest = new ProcessingRequest(['request' => $request]);
 
-        $response = $handler->handleRequest($request);
+        $response = $handler->handleRequest($processingRequest);
         $this->assertInstanceOf(ForbiddenResponse::class, $response);
-        $this->assertEquals(403, $response->httpCode);
+        $this->assertEquals(403, $response->httpCode());
     }
 }

--- a/proxy/tests/unit/lib/middlewares/SetHeadersMiddlewareTest.php
+++ b/proxy/tests/unit/lib/middlewares/SetHeadersMiddlewareTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tent\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Tent\Middlewares\SetHeadersMiddleware;
+use Tent\Models\ProcessingRequest;
+
+class SetHeadersMiddlewareTest extends TestCase
+{
+    public function testOverridingHeaders()
+    {
+        $expectedHeaders = [
+            'Host' => 'some_host',
+            'X-Test' => 'value',
+            'User-Agent' => 'PHPUnit',
+        ];
+        $requestHeaders = [
+            'Host' => 'original_host',
+            'User-Agent' => 'PHPUnit',
+        ];
+
+        $request = new ProcessingRequest([
+            'headers' => $requestHeaders
+        ]);
+
+        $middleware = new SetHeadersMiddleware([
+            'Host' => 'some_host',
+            'X-Test' => 'value',
+        ]);
+
+        $result = $middleware->process($request);
+        $this->assertSame($request, $result);
+        $this->assertEquals($expectedHeaders, $result->headers());
+    }
+}

--- a/proxy/tests/unit/lib/models/ForbiddenResponseTest.php
+++ b/proxy/tests/unit/lib/models/ForbiddenResponseTest.php
@@ -10,8 +10,8 @@ class ForbiddenResponseTest extends TestCase
     public function testReturns403StatusAndDefaultBody()
     {
         $response = new ForbiddenResponse();
-        $this->assertSame(403, $response->httpCode);
-        $this->assertSame('Forbidden', $response->body);
-        $this->assertContains('Content-Type: text/plain', $response->headerLines);
+        $this->assertSame(403, $response->httpCode());
+        $this->assertSame('Forbidden', $response->body());
+        $this->assertContains('Content-Type: text/plain', $response->headerLines());
     }
 }

--- a/proxy/tests/unit/lib/models/MissingResponseTest.php
+++ b/proxy/tests/unit/lib/models/MissingResponseTest.php
@@ -12,21 +12,21 @@ class MissingResponseTest extends TestCase
     {
         $response = new MissingResponse();
 
-        $this->assertEquals(404, $response->httpCode);
+        $this->assertEquals(404, $response->httpCode());
     }
 
     public function testCreatesResponseWithNotFoundBody()
     {
         $response = new MissingResponse();
 
-        $this->assertEquals("Not Found", $response->body);
+        $this->assertEquals("Not Found", $response->body());
     }
 
     public function testCreatesResponseWithTextPlainContentType()
     {
         $response = new MissingResponse();
 
-        $this->assertEquals(['Content-Type: text/plain'], $response->headerLines);
+        $this->assertEquals(['Content-Type: text/plain'], $response->headerLines());
     }
 
     public function testExtendsResponse()

--- a/proxy/tests/unit/lib/service/RequestProcessorTest.php
+++ b/proxy/tests/unit/lib/service/RequestProcessorTest.php
@@ -61,9 +61,9 @@ class RequestProcessorTest extends TestCase
 
         $expectedContent = file_get_contents($this->staticPath . '/index.html');
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertEquals($expectedContent, $response->body);
-        $this->assertStringContainsString('Content-Type: text/html', implode("\n", $response->headerLines));
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertEquals($expectedContent, $response->body());
+        $this->assertStringContainsString('Content-Type: text/html', implode("\n", $response->headerLines()));
     }
 
     public function testProxyRequestHandlerForwardsToHttpbin()
@@ -77,10 +77,10 @@ class RequestProcessorTest extends TestCase
         $response = RequestProcessor::handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->httpCode);
-        $this->assertNotEmpty($response->body);
+        $this->assertEquals(200, $response->httpCode());
+        $this->assertNotEmpty($response->body());
         // httpbin returns JSON for /anything and /get endpoints, so we check for JSON
-        $json = json_decode($response->body, true);
+        $json = json_decode($response->body(), true);
         $this->assertIsArray($json);
         $this->assertArrayHasKey('url', $json);
         $this->assertStringContainsString('/get', $json['url']);
@@ -96,7 +96,7 @@ class RequestProcessorTest extends TestCase
         $response = RequestProcessor::handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(404, $response->httpCode);
-        $this->assertStringContainsString('Not Found', $response->body);
+        $this->assertEquals(404, $response->httpCode());
+        $this->assertStringContainsString('Not Found', $response->body());
     }
 }


### PR DESCRIPTION
# PR: Add RequestMiddleware and Integrate with RequestHandler

This pull request introduces a flexible middleware system for processing HTTP requests before they reach the handler logic.

## Changes
- Introduced the `RequestMiddleware` interface, allowing middlewares to modify a `ProcessingRequest` before it is handled.
- Created example middleware(s), such as `SetHeadersMiddleware`, to demonstrate usage.
- Refactored `RequestHandler`:
  - Renamed the main processing method from `handleRequest` to `processRequest` (now protected/abstract in subclasses).
  - Added a new public `handleRequest` method that applies all registered middlewares to the incoming `ProcessingRequest` before passing it to `processRequest`.
  - Added `addMiddleware` to allow dynamic registration of middlewares on handlers.
- Updated all subclasses and tests to use the new middleware-aware flow.
- Improved documentation for all affected classes and methods.

## Motivation
This change enables composable, reusable request transformations (such as header injection, authentication, logging, etc.) to be applied transparently before the main handler logic. It brings the codebase closer to modern web frameworks and improves testability and extensibility.

## Example Usage
```php
$handler = new SomeRequestHandler();
$handler->addMiddleware(new SetHeadersMiddleware(['X-Test' => 'value']));
$response = $handler->handleRequest($processingRequest);
```

## Impact
- All request handling now supports middleware by default.
- Existing handler logic is preserved, but now runs after all middlewares are applied.
- Backwards-incompatible: subclasses must implement `processRequest` instead of `handleRequest`.

